### PR TITLE
Https Scheme Mistakenly Appended

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -315,15 +315,17 @@ class User extends Authenticatable
 
     private function validateUrlScheme($url, $protocol = "https")
     {
-        $delim = "://";
-        $arr = explode($delim, $url);
+        if(!is_null($url)) {
+          $delim = "://";
+          $arr = explode($delim, $url);
 
-        if (sizeof($arr) == 1) {
+          if (sizeof($arr) == 1) {
 
-            return $protocol . "://" . $url;
+              return $protocol . $delim . $url;
 
+          }
+
+          return $url;
         }
-
-        return $url;
     }
 }


### PR DESCRIPTION
Fixes Https Scheme being appended before ensuring that the `$url` is not null.
I have explained the demerit of this in issue #23 in detail.

modified:   app/User.php

Fixes #23